### PR TITLE
Remove personal access token from CI

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           context: .
           push: true
+          secrets: |
+            NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -44,8 +44,6 @@ jobs:
         with:
           context: .
           push: true
-          secrets: |
-            NODE_AUTH_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -70,9 +68,6 @@ jobs:
           cache: yarn
           registry-url: 'https://npm.pkg.github.com'
           scope: '@credativ'
-          always-auth: true
-        env:
-          NODE_AUTH_TOKEN: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
 
       - name: Install dependencies
         run: yarn install --pure-lockfile --no-progress --network-concurrency 1

--- a/.github/workflows/unit-test-backend.yml
+++ b/.github/workflows/unit-test-backend.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-test-frontend.yml
+++ b/.github/workflows/unit-test-frontend.yml
@@ -30,9 +30,6 @@ jobs:
           cache: yarn
           registry-url: 'https://npm.pkg.github.com'
           scope: '@credativ'
-          always-auth: true
-        env:
-          NODE_AUTH_TOKEN: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
 
       - name: Install dependencies
         run: yarn install --pure-lockfile --no-progress --network-concurrency 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ WORKDIR /usr/src/app/
 COPY package.json yarn.lock ./
 COPY packages packages
 
-RUN --mount=type=secret,id=NODE_AUTH_TOKEN \
-    echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/NODE_AUTH_TOKEN)" > .npmrc && \
-    echo "@credativ:registry=https://npm.pkg.github.com" >> .npmrc && \
+RUN echo "@credativ:registry=https://npm.pkg.github.com" >> .npmrc && \
     yarn install --pure-lockfile --no-progress --network-concurrency 1 && \
     rm .npmrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /usr/src/app/
 COPY package.json yarn.lock ./
 COPY packages packages
 
-RUN echo "@credativ:registry=https://npm.pkg.github.com" >> .npmrc && \
+RUN --mount=type=secret,id=NODE_AUTH_TOKEN \
+    echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/NODE_AUTH_TOKEN)" > .npmrc && \
+    echo "@credativ:registry=https://npm.pkg.github.com" >> .npmrc && \
     yarn install --pure-lockfile --no-progress --network-concurrency 1 && \
     rm .npmrc
 


### PR DESCRIPTION
The GITHUB_TOKEN is still needed to access the node packages even though the repositories are public.