### PR TITLE
Pass NODE_AUTH_TOKEN to yarn install

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --pure-lockfile --no-progress --network-concurrency 1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cypress
         run: node_modules/cypress/bin/cypress install

--- a/.github/workflows/unit-test-frontend.yml
+++ b/.github/workflows/unit-test-frontend.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --pure-lockfile --no-progress --network-concurrency 1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Type check
         run: yarn typecheck


### PR DESCRIPTION
Fixes 401 Unauthorized errors when fetching from the GitHub npm registry.