### PR TITLE
Speedup image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14.15.5-alpine3.13 as js-builder
+# Frontend builder stage
+FROM --platform=$BUILDPLATFORM docker.io/library/node:14.15.5-alpine3.13 as js-builder
 
 RUN apk add --no-cache git
 
@@ -23,7 +24,8 @@ ENV NODE_ENV=production \
     NODE_OPTIONS="--max_old_space_size=4096"
 RUN yarn build
 
-FROM golang:1.19.4-alpine3.17 as go-builder
+# Backend builder stage
+FROM docker.io/library/golang:1.19.4-alpine3.17 as go-builder
 
 RUN apk add --no-cache gcc g++
 
@@ -43,7 +45,7 @@ RUN go run build.go build && \
     mv /go/src/github.com/credativ/plutono/bin/linux-$(go env GOARCH)/plutono-cli /go/src/github.com/credativ/plutono/bin/
 
 # Final stage
-FROM alpine:3.17
+FROM docker.io/library/alpine:3.17 as final
 
 ARG PL_UID="472"
 ARG PL_GID="0"


### PR DESCRIPTION
Go builds will remain emulated
JS builds will be "cross built" from docker's perspective

--

Podman doesn't produce the correct manifest, let's see if Docker does...