### PR TITLE
Update Go in unit tests to 1.21.6

### DIFF
--- a/.github/workflows/unit-test-backend.yml
+++ b/.github/workflows/unit-test-backend.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.5
+          go-version: 1.21.6
           cache: true
           cache-dependency-path: |
               **/go.sum


### PR DESCRIPTION
The Go version was updated to 1.21.6 in Plutono 7.29, but the update was overlooked in the unit tests. This commit remedies that oversight.