### PR TITLE
Add roleAttributePath to GitHub Social Auth

### DIFF
--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -126,6 +126,7 @@ func NewOAuthService() {
 				SocialBase:           newSocialBase(name, &config, info),
 				apiUrl:               info.ApiUrl,
 				teamIds:              sec.Key("team_ids").Ints(","),
+				roleAttributePath:    info.RoleAttributePath,
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
 			}
 		}


### PR DESCRIPTION
This PR adds the `roleAttributePath` functionality to the GitHub social auth plugin for automatic permission provisioning based on a user's GitHub team membership.

An example:
```bash
role_attribute_path = "contains(groups[*], '@org/team') && 'Admin' || 'Viewer'"
```
will give `Admin` access to anyone who is a member of the `org/team` team.