### PR TITLE
Prevent org admins from deleting instance admins

### DIFF
--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -197,7 +197,7 @@ func RemoveOrgUser(cmd *models.RemoveOrgUserCommand) error {
 					return err
 				}
 			}
-		} else if cmd.ShouldDeleteOrphanedUser {
+		} else if cmd.ShouldDeleteOrphanedUser && !user.IsAdmin {
 			// no other orgs, delete the full user
 			if err := deleteUserInTransaction(sess, &models.DeleteUserCommand{UserId: user.Id}); err != nil {
 				return err


### PR DESCRIPTION
Previously organization admins could delete instance admin accounts by
removing them from the organization if this was the last organization
the instance admin was a member of.