### PR TITLE
Protect DingDing contact points

### DIFF
--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -14,7 +14,7 @@ import (
 const defaultDingdingMsgType = "link"
 
 func patchDingDingURLFromSecureSettings(model *models.AlertNotification) {
-	if secretUrl, err := model.DecryptedValue("url"); err == nil && secretUrl != "" {
+	if secretUrl := model.DecryptedValue("url"); secretUrl != "" {
 		model.Settings.Set("url", secretUrl)
 	}
 }

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -15,7 +15,8 @@ const defaultDingdingMsgType = "link"
 
 func patchDingDingURLFromSecureSettings(model *models.AlertNotification) {
 	if model.SecureSettings != nil {
-		if secretUrl, ok := model.SecureSettings["url"].(string); ok && secretUrl != "" {
+		if secretUrlBytes, ok := model.SecureSettings["url"].([]byte); ok && len(secretUrlBytes) > 0 {
+			secretUrl := string(secretUrlBytes)
 			model.Settings.Set("url", secretUrl)
 		}
 	}

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -13,6 +13,14 @@ import (
 
 const defaultDingdingMsgType = "link"
 
+func patchDingDingURLFromSecureSettings(model *models.AlertNotification) {
+	if model.SecureSettings != nil {
+		if secretUrl, ok := model.SecureSettings["url"].(string); ok && secretUrl != "" {
+			model.Settings.Set("url", secretUrl)
+		}
+	}
+}
+
 func init() {
 	alerting.RegisterNotifier(&alerting.NotifierPlugin{
 		Type:        "dingding",
@@ -28,6 +36,7 @@ func init() {
 				Placeholder:  "https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx",
 				PropertyName: "url",
 				Required:     true,
+				Secure:       true,
 			},
 			{
 				Label:        "Message Type",
@@ -48,6 +57,9 @@ func init() {
 }
 
 func newDingDingNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+
+	patchDingDingURLFromSecureSettings(model)
+
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find url property in settings"}

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -14,11 +14,8 @@ import (
 const defaultDingdingMsgType = "link"
 
 func patchDingDingURLFromSecureSettings(model *models.AlertNotification) {
-	if model.SecureSettings != nil {
-		if secretUrlBytes, ok := model.SecureSettings["url"].([]byte); ok && len(secretUrlBytes) > 0 {
-			secretUrl := string(secretUrlBytes)
-			model.Settings.Set("url", secretUrl)
-		}
+	if secretUrl, err := model.DecryptedValue("url"); err == nil && secretUrl != "" {
+		model.Settings.Set("url", secretUrl)
 	}
 }
 

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -14,9 +14,24 @@ import (
 const defaultDingdingMsgType = "link"
 
 func patchDingDingURLFromSecureSettings(model *models.AlertNotification) {
-	if secretUrl := model.DecryptedValue("url"); secretUrl != "" {
-		model.Settings.Set("url", secretUrl)
-	}
+        if model.SecureSettings != nil {
+                value, exists := model.SecureSettings["url"]
+                if !exists {
+                        fmt.Println("Key 'url' not found in SecureSettings")
+                        return
+                }
+
+                secretUrlBytes, ok := value.([]byte)
+                if !ok {
+                        fmt.Printf("Invalid type for 'url', expected []byte but got %T\n", value)
+                        return
+                }
+                
+                if len(secretUrlBytes) > 0 {
+                        secretUrl := string(secretUrlBytes)
+                        model.Settings.Set("url", secretUrl)
+                }
+        }
 }
 
 func init() {


### PR DESCRIPTION
With this patch, DingDing contact points should be protected against exposure in alerting:

It marks the DingDing webhook URL as a "secret" in Plutono's backend configuration. So it should ensure that, if the URL is stored in encrypted SecureSettings, that it is safely copied to the main settings before usage. This should prevent DingDing webhook credentials from being exposed in plaintext in configs or logs or whatever (just like other secrets in the system).